### PR TITLE
Fix //e2e:prodserver_test and add this test back to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,6 +71,9 @@ jobs:
       - run: yarn ng test
       - run: yarn ng e2e
 
+      # Also run prodserver test which is not covered by `ng e2e`
+      - run: yarn bazel test //e2e:prodserver_test
+
       - store_artifacts:
           path: dist/bin/src/bundle.min.js
           destination: bundle.min.js

--- a/e2e/protractor.on-prepare.js
+++ b/e2e/protractor.on-prepare.js
@@ -14,10 +14,12 @@ module.exports = function(config) {
   // selected port (given a port flag to pass to the server as an argument).
   // The port used is returned in serverSpec and the protractor serverUrl
   // is the configured.
-  const portFlag = config.server.endsWith('prodserver') ? '-p' : '-port';
-  return protractorUtils.runServer(config.workspace, config.server, portFlag, [])
+  const isProdserver = config.server.endsWith('prodserver');
+  return protractorUtils
+      .runServer(config.workspace, config.server, isProdserver ? '-p' : '-port', [])
       .then(serverSpec => {
-        const serverUrl = `http://localhost:${serverSpec.port}`;
+        // Example app is hosted under `/example` in the prodserver and under `/` in devserver
+        const serverUrl = `http://localhost:${serverSpec.port}` + (isProdserver ? '/example' : '');
         protractor.browser.baseUrl = serverUrl;
       });
 };

--- a/e2e/src/app.po.ts
+++ b/e2e/src/app.po.ts
@@ -2,7 +2,7 @@ import { browser, by, element } from 'protractor';
 
 export class AppPage {
   async navigateTo() {
-    await browser.get('/hello');
+    await browser.get(browser.baseUrl + '/hello');
     return browser.waitForAngular();
   }
 

--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -197,7 +197,14 @@ web_package(
 history_server(
     name = "prodserver",
     data = [":prodapp"],
-    templated_args = ["src/prodapp"],
+    # '-a src/prodapp' will ask history-server to scan for all apps under the
+    # given folder this will result in the following auto-configuration:
+    #   /example => src/prodapp/example
+    #   /        => src/prodapp
+    templated_args = [
+        "-a",
+        "src/prodapp",
+    ],
 )
 
 nodejs_image(


### PR DESCRIPTION
This was broken when the landing page was added and the example app was moved to the /example URL but the break wasn't noticed since CI is running `ng test` which doesn't run //e2e/prodserver_test