### PR TITLE
WIP: Example of using @auth0/angular-jwt npm package

### DIFF
--- a/angular-metadata.tsconfig.json
+++ b/angular-metadata.tsconfig.json
@@ -19,12 +19,10 @@
     },
     "include": [
         "node_modules/@angular/**/*",
+        "node_modules/@auth0/angular-jwt/**/*",
         "node_modules/@ngrx/**/*"
     ],
     "exclude": [
-        "node_modules/@ngrx/store/migrations/**",
-        "node_modules/@ngrx/store/schematics/**",
-        "node_modules/@ngrx/store/schematics-core/**",
         "node_modules/@angular/cdk/schematics/**",
         "node_modules/@angular/cdk/typings/schematics/**",
         "node_modules/@angular/material/schematics/**",
@@ -33,7 +31,9 @@
         "node_modules/@angular/router/upgrade*",
         "node_modules/@angular/bazel/**",
         "node_modules/@angular/compiler-cli/**",
-        "node_modules/@angular/**/testing/**"
-        
+        "node_modules/@angular/**/testing/**",
+        "node_modules/@ngrx/store/migrations/**",
+        "node_modules/@ngrx/store/schematics/**",
+        "node_modules/@ngrx/store/schematics-core/**"
     ]
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
         "@angular/platform-browser": "8.0.0",
         "@angular/platform-browser-dynamic": "8.0.0",
         "@angular/router": "8.0.0",
+        "@auth0/angular-jwt": "^2.1.0",
         "@ngrx/store": "8.0.1",
         "date-fns": "1.30.1",
         "rxjs": "6.4.0",

--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -163,6 +163,7 @@ rollup_bundle(
         "@npm//@angular/material",
         "@npm//@angular/platform-browser",
         "@npm//@angular/router",
+        "@npm//@auth0/angular-jwt",
         "@npm//@ngrx/store",
         "@npm//rxjs",
     ],

--- a/src/app/BUILD.bazel
+++ b/src/app/BUILD.bazel
@@ -38,6 +38,7 @@ ng_module(
         "@npm//@angular/core",
         "@npm//@angular/router",
         "@npm//@angular/platform-browser",
+        "@npm//@auth0/angular-jwt",
         "@npm//@ngrx/store",
     ],
 )

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -2,6 +2,7 @@
 import {NgModule} from '@angular/core';
 import {BrowserModule} from '@angular/platform-browser';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
+import {JwtModule} from '@auth0/angular-jwt';
 import {StoreModule} from '@ngrx/store';
 
 import {MaterialModule} from '../shared/material/material.module';
@@ -21,13 +22,19 @@ import {StorageModule} from './storage/storage.module';
 import {SupportModule} from './support/support.module';
 import {todoReducer} from './todos/reducers/reducers';
 
+export function tokenGetter() {
+  return 'token';
+}
+
+
+
 @NgModule({
   declarations: [AppComponent],
   imports: [
     AppRoutingModule, BrowserModule, BrowserAnimationsModule, MaterialModule, HomeModule,
     StoreModule.forRoot({todoReducer}), BillingModule, ComputeModule, DatastoreModule,
     FunctionsModule, LoggingModule, MonitoringModule, NetworkingModule, RegistryModule,
-    StorageModule, SupportModule
+    StorageModule, SupportModule, JwtModule.forRoot({config: {tokenGetter}})
   ],
   exports: [AppComponent],
   bootstrap: [AppComponent],

--- a/yarn.lock
+++ b/yarn.lock
@@ -201,6 +201,13 @@
   dependencies:
     tslib "^1.9.0"
 
+"@auth0/angular-jwt@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@auth0/angular-jwt/-/angular-jwt-2.1.0.tgz#5c90ee7d927e70cefa8db7c89a64eb67c05a912d"
+  integrity sha512-1KFtqswmJeM8JiniagSenpwHKTf9l+W+TmfsWV+x9SoZIShc6YmBsZDxd+oruZJL7MbJlxIJ3SQs7Yl1wraQdg==
+  dependencies:
+    url "^0.11.0"
+
 "@bazel/bazel-darwin_x64@0.26.1":
   version "0.26.1"
   resolved "https://registry.yarnpkg.com/@bazel/bazel-darwin_x64/-/bazel-darwin_x64-0.26.1.tgz#1b5c69b635e5c2a8c3090fa5f6bcb45735f06045"
@@ -4536,6 +4543,11 @@ pumpify@^1.3.3:
     inherits "^2.0.3"
     pump "^2.0.0"
 
+punycode@1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
+  integrity sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=
+
 punycode@^1.3.2, punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
@@ -4579,6 +4591,11 @@ qs@~6.4.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
   integrity sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=
+
+querystring@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
+  integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
 
 range-parser@^1.2.0:
   version "1.2.0"
@@ -5845,6 +5862,14 @@ url-parse-lax@^1.0.0:
   integrity sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=
   dependencies:
     prepend-http "^1.0.1"
+
+url@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"
+  integrity sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=
+  dependencies:
+    punycode "1.3.2"
+    querystring "0.2.0"
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
Example of usage of @auth0/angular-jwt for issue #291.

This is a WIP. #291 was based on an older version of this example when angular/angular was still build from source. I've based this example on the latest. The error observed in #291 is not seen here but there are a few other issues with the `@auth0/angular-jwt` npm package that need resolving before it can be used with Bazel.

-----------

1) There is an rxjs deep import that breaks bundling.

```
ERROR: /Users/greg/google/angular-bazel-example/src/BUILD.bazel:146:1: Bundling JavaScript src/bundle_chunks_es2015 [rollup] failed (Exit 1) rollup failed: error executing command bazel-out/host/bin/external/build_bazel_rules_nodejs/internal/rollup/rollup --config bazel-out/darwin-fastbuild/bin/src/_bundle.rollup.conf.js --output.dir ... (remaining 3 argument(s) skipped)

Use --sandbox_debug to see verbose messages from the sandbox
[!] Error: 'from' is not exported by bazel-out/darwin-fastbuild/bin/src/bundle.es6/external/npm/node_modules/rxjs/internal/observable/from.js
https://rollupjs.org/guide/en#error-name-is-not-exported-by-module-
bazel-out/darwin-fastbuild/bin/src/bundle.es6/external/npm/node_modules/@auth0/angular-jwt/src/jwt.interceptor.js (4:9)
2: import { JwtHelperService } from './jwthelper.service';
3: import { JWT_OPTIONS } from './jwtoptions.token';
4: import { from } from "rxjs/internal/observable/from";
            ^
5: import { mergeMap } from 'rxjs/operators';
6: import { parse } from 'url';
Error: 'from' is not exported by bazel-out/darwin-fastbuild/bin/src/bundle.es6/external/npm/node_modules/rxjs/internal/observable/from.js
```

Not 100% why rollup_bundle is failing but in any case the import needs to be changed to: `import { from } from "rxjs"` which may require updating to a newer rxjs. The deep import wouldn't work in devmode anyway.

-----------

2) `@auth0/angular-jwt` package.json `main` points to an unnamed UMD bundle: `"main": "bundles/core.umd.js",`:

```
define&&define.amd?define(["@angular/core","@angular/common/http","rxjs/operators","rxjs/internal/observable/from"]
```

`bundles/core.umd.js` gets automatically picked up by ts_devserver as the npm package looks like its in APF (angular package format). However, because the UMD bundle is not named it breaks devmode at runtime:

```
Uncaught Error: Mismatched anonymous define() module: function(t,e,r,n){return function(t){var e={};function r(n){if(e[n])return e[n].exports;var o=e[n]={i:n,l:!1,exports:{}};return t[n].call(o.exports,o,o.exports,r),o.l=!0,o.exports}return r.m=t,r.c=e,r.d=function(t,e,n){r.o(t,e)||Object.defineProperty(t,e,{configurable:!1,enumerable:!0,get:n})},r.r=function(t){Object.defineProperty(t,"__esModule",{value:!0})},r.n=function(t){var e=t&&t.__esModule?function(){return t.default}:function(){return...
```

@kyliau I think we should update the check on APF to check if the `umd.js` file is named-AMD or named-UMD.

// cc @alexeagle @mgechev 