### PR TITLE
Update to rollup_bundle with enable_code_splitting

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -17,8 +17,8 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch rules_nodejs so we can install our npm dependencies
 http_archive(
     name = "build_bazel_rules_nodejs",
-    sha256 = "7c4a690268be97c96f04d505224ec4cb1ae53c2c2b68be495c9bd2634296a5cd",
-    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/0.34.0/rules_nodejs-0.34.0.tar.gz"],
+    sha256 = "6625259f9f77ef90d795d20df1d0385d9b3ce63b6619325f702b6358abb4ab33",
+    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/0.35.0/rules_nodejs-0.35.0.tar.gz"],
 )
 
 # Fetch sass rules for compiling sass files

--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -128,33 +128,8 @@ ts_devserver(
     deps = ["//src"],
 )
 
-# This list is auto-updated by /tools/generator
-# Make sure not to rename this variable
-GENERATED_FEATURES = [
-    "src/app/billing/billing.module.ngfactory",
-    "src/app/compute/compute.module.ngfactory",
-    "src/app/datastore/datastore.module.ngfactory",
-    "src/app/functions/functions.module.ngfactory",
-    "src/app/logging/logging.module.ngfactory",
-    "src/app/monitoring/monitoring.module.ngfactory",
-    "src/app/networking/networking.module.ngfactory",
-    "src/app/registry/registry.module.ngfactory",
-    "src/app/storage/storage.module.ngfactory",
-    "src/app/support/support.module.ngfactory",
-]
-
 rollup_bundle(
     name = "bundle",
-    # These Angular routes may be lazy-loaded at runtime.
-    # So we tell Rollup that it can put them in separate JS chunks
-    # (code-splitting) for faster application startup.
-    # In the future, we could automatically gather these from statically
-    # analyzing the Angular sources.
-    additional_entry_points = [
-        "src/app/home/home.ngfactory",
-        "src/app/hello-world/hello-world.module.ngfactory",
-        "src/app/todos/todos.module.ngfactory",
-    ] + GENERATED_FEATURES,
     entry_point = ":main.prod.ts",
     deps = [
         "//src",

--- a/src/app/BUILD.bazel
+++ b/src/app/BUILD.bazel
@@ -10,27 +10,22 @@ NG_FACTORY_ADDED_IMPORTS = [
     "@npm//@angular/forms",
 ]
 
-# This list is auto-updated by /tools/generator
-# Make sure not to rename this variable
-GENERATED_FEATURES = [
-    "//src/app/billing",
-    "//src/app/compute",
-    "//src/app/datastore",
-    "//src/app/functions",
-    "//src/app/logging",
-    "//src/app/monitoring",
-    "//src/app/networking",
-    "//src/app/registry",
-    "//src/app/storage",
-    "//src/app/support",
-]
-
 ng_module(
     name = "app",
     srcs = glob(["*.ts"]),
     assets = ["app.component.html"],
     tsconfig = "//src:tsconfig.json",
-    deps = NG_FACTORY_ADDED_IMPORTS + GENERATED_FEATURES + [
+    deps = NG_FACTORY_ADDED_IMPORTS + [
+        "//src/app/billing",
+        "//src/app/compute",
+        "//src/app/datastore",
+        "//src/app/functions",
+        "//src/app/logging",
+        "//src/app/monitoring",
+        "//src/app/networking",
+        "//src/app/registry",
+        "//src/app/storage",
+        "//src/app/support",
         "//src/app/hello-world",
         "//src/app/home",
         "//src/app/todos",

--- a/tools/generator/src/build-file.js
+++ b/tools/generator/src/build-file.js
@@ -1,6 +1,5 @@
 
 const fs = require('fs');
-const { generatedFeaturesListInBuildFileRegex } = require('./utils');
 
 module.exports.writeModuleBuildFile =
     function writeModuleBuildFile(file, {modIdx, scssFileAcc, tsFileAcc, htmlFileAcc}) {
@@ -122,23 +121,4 @@ ng_module(
     ],
 )
     `);
-}
-
-        module.exports.updateBuildFile = function updateBuildFile(file, {mappedFeatureList}) {
-  const shouldAddTraillingComma = () => mappedFeatureList.length === 0 ? '' : ',';
-  const featuresList = `GENERATED_FEATURES = [
-    ${mappedFeatureList.join(',\n    ')}${shouldAddTraillingComma()}
-]`
-
-  const originalRootBuildFileContent = fs.readFileSync(file, {encoding: 'utf-8'});
-
-  if (generatedFeaturesListInBuildFileRegex.test(originalRootBuildFileContent) === false) {
-    console.error('ERROR', `couldn't find declaration 'GENERATED_FEATURES' in '${file}'.`);
-    process.exit(1);
-  }
-
-  console.log(`UPDATE ${file}`);
-  fs.writeFileSync(
-      file,
-      originalRootBuildFileContent.replace(generatedFeaturesListInBuildFileRegex, featuresList))
 }

--- a/tools/generator/src/clean.js
+++ b/tools/generator/src/clean.js
@@ -1,6 +1,5 @@
 const rimraf = require('rimraf');
 const { FEATURES } = require('./feature-names');
-const { updateBuildFile } = require('./build-file');
 const { updateNgModule, removeRoutesFromNgModule, removeRoutesFromAppComponentHtml } = require('./ng-module');
 
 module.exports = function() {
@@ -9,8 +8,6 @@ module.exports = function() {
     rimraf.sync(featPath);
   });
 
-  updateBuildFile('src/app/BUILD.bazel', {mappedFeatureList: []});
-  updateBuildFile('src/BUILD.bazel', {mappedFeatureList: []});
   updateNgModule('src/app/app.module.ts');
   removeRoutesFromNgModule('src/app/app-routing.module.ts');
   removeRoutesFromAppComponentHtml('src/app/app.component.html');

--- a/tools/generator/src/generate.js
+++ b/tools/generator/src/generate.js
@@ -1,23 +1,11 @@
 
 const { makeFeatureModule } = require('./create-feature-module');
-const { updateBuildFile } = require('./build-file');
 const { updateRoutesInAppComponentHtml, updateRoutesInNgModule } = require('./ng-module');
 const { FEATURES } = require('./feature-names');
 
 module.exports = function(argv) {
   // Create all feature modules and update BUILD files
   FEATURES.forEach(makeFeatureModule(argv));
-
-  // Update src/app/BUILD file and reference all the feature modules
-  updateBuildFile(
-      'src/app/BUILD.bazel',
-      {mappedFeatureList: FEATURES.map(_feature => `"//src/app/${_feature.path}"`)});
-
-  // Update src/BUILD file and reference all the feature ngfactories
-  updateBuildFile('src/BUILD.bazel', {
-    mappedFeatureList:
-        FEATURES.map(_feature => `"src/app/${_feature.path}/${_feature.path}.module.ngfactory"`)
-  });
 
   // Update routing module with routes definition
   updateRoutesInNgModule(

--- a/tools/generator/src/utils.js
+++ b/tools/generator/src/utils.js
@@ -1,13 +1,5 @@
 const { FEATURES } = require('./feature-names');
 
-// This will match:
-// GENERATED_FEATURES = [
-//   "file/path/to/module",
-//   ...
-// ]
-module.exports.generatedFeaturesListInBuildFileRegex =
-    /GENERATED_FEATURES[ =]+\[[\s"/a-z0-9,-.]*\]/;
-
 // This will match"
 // <a mat-list-item routerLink="/storage"><mat-icon>folder</mat-icon> Storage </a>
 module.exports.routeLinkRegex = new RegExp(`<a.*?routerLink="\/(${FEATURES.map(feature => feature.path).join('|')})">[\\w\\W\\s'"<>]+?<\/a>`, 'mg');


### PR DESCRIPTION
We no longer need to specify the additional entry points

Note that the chunks no longer get names like `monitoring.module.ngfactory.js` is now `chunk-9eb5c295.js` but that's okay because Rollup rewrote the import site as well.
It so happens even though these are top-level routes, they never needed to be 'entry_points' because we never had a script tag that tries to load them, they are always imported through the main.