### PR TITLE
Split ts_web_test_suite tests into circleci and bazelci versions with no-bazelci and no-circleci tags

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,3 +1,0 @@
-steps:
-  - label: Lint
-    command: yarn && yarn buildifier -mode=check

--- a/.circleci/bazel.rc
+++ b/.circleci/bazel.rc
@@ -6,8 +6,8 @@
 # TODO: re-enable after we deal with 10m timeout on circleci
 #build --noshow_progress
 
-# Don't run manual tests
-test --test_tag_filters=-manual
+# Don't run tests that are not meant to be run on circleci
+test --test_tag_filters=-no-circleci
 
 # Print all the options that apply to the build.
 # This helps us diagnose which options override others

--- a/src/app/billing/module0/BUILD.bazel
+++ b/src/app/billing/module0/BUILD.bazel
@@ -1,8 +1,8 @@
 # Generated BUILD file, see /tools/generator
 load("@io_bazel_rules_sass//:defs.bzl", "sass_binary")
 load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("@npm_bazel_karma//:defs.bzl", "ts_web_test_suite")
 load("@npm_bazel_typescript//:defs.bzl", "ts_library")
+load("//tools:defaults.bzl", "ts_web_test_suite")
 
 package(default_visibility = ["//:__subpackages__"])
 

--- a/src/app/billing/module1/BUILD.bazel
+++ b/src/app/billing/module1/BUILD.bazel
@@ -1,8 +1,8 @@
 # Generated BUILD file, see /tools/generator
 load("@io_bazel_rules_sass//:defs.bzl", "sass_binary")
 load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("@npm_bazel_karma//:defs.bzl", "ts_web_test_suite")
 load("@npm_bazel_typescript//:defs.bzl", "ts_library")
+load("//tools:defaults.bzl", "ts_web_test_suite")
 
 package(default_visibility = ["//:__subpackages__"])
 

--- a/src/app/compute/module0/BUILD.bazel
+++ b/src/app/compute/module0/BUILD.bazel
@@ -1,8 +1,8 @@
 # Generated BUILD file, see /tools/generator
 load("@io_bazel_rules_sass//:defs.bzl", "sass_binary")
 load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("@npm_bazel_karma//:defs.bzl", "ts_web_test_suite")
 load("@npm_bazel_typescript//:defs.bzl", "ts_library")
+load("//tools:defaults.bzl", "ts_web_test_suite")
 
 package(default_visibility = ["//:__subpackages__"])
 

--- a/src/app/compute/module1/BUILD.bazel
+++ b/src/app/compute/module1/BUILD.bazel
@@ -1,8 +1,8 @@
 # Generated BUILD file, see /tools/generator
 load("@io_bazel_rules_sass//:defs.bzl", "sass_binary")
 load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("@npm_bazel_karma//:defs.bzl", "ts_web_test_suite")
 load("@npm_bazel_typescript//:defs.bzl", "ts_library")
+load("//tools:defaults.bzl", "ts_web_test_suite")
 
 package(default_visibility = ["//:__subpackages__"])
 

--- a/src/app/datastore/module0/BUILD.bazel
+++ b/src/app/datastore/module0/BUILD.bazel
@@ -1,8 +1,8 @@
 # Generated BUILD file, see /tools/generator
 load("@io_bazel_rules_sass//:defs.bzl", "sass_binary")
 load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("@npm_bazel_karma//:defs.bzl", "ts_web_test_suite")
 load("@npm_bazel_typescript//:defs.bzl", "ts_library")
+load("//tools:defaults.bzl", "ts_web_test_suite")
 
 package(default_visibility = ["//:__subpackages__"])
 

--- a/src/app/datastore/module1/BUILD.bazel
+++ b/src/app/datastore/module1/BUILD.bazel
@@ -1,8 +1,8 @@
 # Generated BUILD file, see /tools/generator
 load("@io_bazel_rules_sass//:defs.bzl", "sass_binary")
 load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("@npm_bazel_karma//:defs.bzl", "ts_web_test_suite")
 load("@npm_bazel_typescript//:defs.bzl", "ts_library")
+load("//tools:defaults.bzl", "ts_web_test_suite")
 
 package(default_visibility = ["//:__subpackages__"])
 

--- a/src/app/functions/module0/BUILD.bazel
+++ b/src/app/functions/module0/BUILD.bazel
@@ -1,8 +1,8 @@
 # Generated BUILD file, see /tools/generator
 load("@io_bazel_rules_sass//:defs.bzl", "sass_binary")
 load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("@npm_bazel_karma//:defs.bzl", "ts_web_test_suite")
 load("@npm_bazel_typescript//:defs.bzl", "ts_library")
+load("//tools:defaults.bzl", "ts_web_test_suite")
 
 package(default_visibility = ["//:__subpackages__"])
 

--- a/src/app/functions/module1/BUILD.bazel
+++ b/src/app/functions/module1/BUILD.bazel
@@ -1,8 +1,8 @@
 # Generated BUILD file, see /tools/generator
 load("@io_bazel_rules_sass//:defs.bzl", "sass_binary")
 load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("@npm_bazel_karma//:defs.bzl", "ts_web_test_suite")
 load("@npm_bazel_typescript//:defs.bzl", "ts_library")
+load("//tools:defaults.bzl", "ts_web_test_suite")
 
 package(default_visibility = ["//:__subpackages__"])
 

--- a/src/app/hello-world/BUILD.bazel
+++ b/src/app/hello-world/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_sass//:defs.bzl", "sass_binary")
 load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("@npm_bazel_karma//:defs.bzl", "ts_web_test_suite")
 load("@npm_bazel_typescript//:defs.bzl", "ts_library")
+load("//tools:defaults.bzl", "ts_web_test_suite")
 
 package(default_visibility = ["//:__subpackages__"])
 

--- a/src/app/logging/module0/BUILD.bazel
+++ b/src/app/logging/module0/BUILD.bazel
@@ -1,8 +1,8 @@
 # Generated BUILD file, see /tools/generator
 load("@io_bazel_rules_sass//:defs.bzl", "sass_binary")
 load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("@npm_bazel_karma//:defs.bzl", "ts_web_test_suite")
 load("@npm_bazel_typescript//:defs.bzl", "ts_library")
+load("//tools:defaults.bzl", "ts_web_test_suite")
 
 package(default_visibility = ["//:__subpackages__"])
 

--- a/src/app/logging/module1/BUILD.bazel
+++ b/src/app/logging/module1/BUILD.bazel
@@ -1,8 +1,8 @@
 # Generated BUILD file, see /tools/generator
 load("@io_bazel_rules_sass//:defs.bzl", "sass_binary")
 load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("@npm_bazel_karma//:defs.bzl", "ts_web_test_suite")
 load("@npm_bazel_typescript//:defs.bzl", "ts_library")
+load("//tools:defaults.bzl", "ts_web_test_suite")
 
 package(default_visibility = ["//:__subpackages__"])
 

--- a/src/app/monitoring/module0/BUILD.bazel
+++ b/src/app/monitoring/module0/BUILD.bazel
@@ -1,8 +1,8 @@
 # Generated BUILD file, see /tools/generator
 load("@io_bazel_rules_sass//:defs.bzl", "sass_binary")
 load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("@npm_bazel_karma//:defs.bzl", "ts_web_test_suite")
 load("@npm_bazel_typescript//:defs.bzl", "ts_library")
+load("//tools:defaults.bzl", "ts_web_test_suite")
 
 package(default_visibility = ["//:__subpackages__"])
 

--- a/src/app/monitoring/module1/BUILD.bazel
+++ b/src/app/monitoring/module1/BUILD.bazel
@@ -1,8 +1,8 @@
 # Generated BUILD file, see /tools/generator
 load("@io_bazel_rules_sass//:defs.bzl", "sass_binary")
 load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("@npm_bazel_karma//:defs.bzl", "ts_web_test_suite")
 load("@npm_bazel_typescript//:defs.bzl", "ts_library")
+load("//tools:defaults.bzl", "ts_web_test_suite")
 
 package(default_visibility = ["//:__subpackages__"])
 

--- a/src/app/networking/module0/BUILD.bazel
+++ b/src/app/networking/module0/BUILD.bazel
@@ -1,8 +1,8 @@
 # Generated BUILD file, see /tools/generator
 load("@io_bazel_rules_sass//:defs.bzl", "sass_binary")
 load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("@npm_bazel_karma//:defs.bzl", "ts_web_test_suite")
 load("@npm_bazel_typescript//:defs.bzl", "ts_library")
+load("//tools:defaults.bzl", "ts_web_test_suite")
 
 package(default_visibility = ["//:__subpackages__"])
 

--- a/src/app/networking/module1/BUILD.bazel
+++ b/src/app/networking/module1/BUILD.bazel
@@ -1,8 +1,8 @@
 # Generated BUILD file, see /tools/generator
 load("@io_bazel_rules_sass//:defs.bzl", "sass_binary")
 load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("@npm_bazel_karma//:defs.bzl", "ts_web_test_suite")
 load("@npm_bazel_typescript//:defs.bzl", "ts_library")
+load("//tools:defaults.bzl", "ts_web_test_suite")
 
 package(default_visibility = ["//:__subpackages__"])
 

--- a/src/app/registry/module0/BUILD.bazel
+++ b/src/app/registry/module0/BUILD.bazel
@@ -1,8 +1,8 @@
 # Generated BUILD file, see /tools/generator
 load("@io_bazel_rules_sass//:defs.bzl", "sass_binary")
 load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("@npm_bazel_karma//:defs.bzl", "ts_web_test_suite")
 load("@npm_bazel_typescript//:defs.bzl", "ts_library")
+load("//tools:defaults.bzl", "ts_web_test_suite")
 
 package(default_visibility = ["//:__subpackages__"])
 

--- a/src/app/registry/module1/BUILD.bazel
+++ b/src/app/registry/module1/BUILD.bazel
@@ -1,8 +1,8 @@
 # Generated BUILD file, see /tools/generator
 load("@io_bazel_rules_sass//:defs.bzl", "sass_binary")
 load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("@npm_bazel_karma//:defs.bzl", "ts_web_test_suite")
 load("@npm_bazel_typescript//:defs.bzl", "ts_library")
+load("//tools:defaults.bzl", "ts_web_test_suite")
 
 package(default_visibility = ["//:__subpackages__"])
 

--- a/src/app/storage/module0/BUILD.bazel
+++ b/src/app/storage/module0/BUILD.bazel
@@ -1,8 +1,8 @@
 # Generated BUILD file, see /tools/generator
 load("@io_bazel_rules_sass//:defs.bzl", "sass_binary")
 load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("@npm_bazel_karma//:defs.bzl", "ts_web_test_suite")
 load("@npm_bazel_typescript//:defs.bzl", "ts_library")
+load("//tools:defaults.bzl", "ts_web_test_suite")
 
 package(default_visibility = ["//:__subpackages__"])
 

--- a/src/app/storage/module1/BUILD.bazel
+++ b/src/app/storage/module1/BUILD.bazel
@@ -1,8 +1,8 @@
 # Generated BUILD file, see /tools/generator
 load("@io_bazel_rules_sass//:defs.bzl", "sass_binary")
 load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("@npm_bazel_karma//:defs.bzl", "ts_web_test_suite")
 load("@npm_bazel_typescript//:defs.bzl", "ts_library")
+load("//tools:defaults.bzl", "ts_web_test_suite")
 
 package(default_visibility = ["//:__subpackages__"])
 

--- a/src/app/support/module0/BUILD.bazel
+++ b/src/app/support/module0/BUILD.bazel
@@ -1,8 +1,8 @@
 # Generated BUILD file, see /tools/generator
 load("@io_bazel_rules_sass//:defs.bzl", "sass_binary")
 load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("@npm_bazel_karma//:defs.bzl", "ts_web_test_suite")
 load("@npm_bazel_typescript//:defs.bzl", "ts_library")
+load("//tools:defaults.bzl", "ts_web_test_suite")
 
 package(default_visibility = ["//:__subpackages__"])
 

--- a/src/app/support/module1/BUILD.bazel
+++ b/src/app/support/module1/BUILD.bazel
@@ -1,8 +1,8 @@
 # Generated BUILD file, see /tools/generator
 load("@io_bazel_rules_sass//:defs.bzl", "sass_binary")
 load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("@npm_bazel_karma//:defs.bzl", "ts_web_test_suite")
 load("@npm_bazel_typescript//:defs.bzl", "ts_library")
+load("//tools:defaults.bzl", "ts_web_test_suite")
 
 package(default_visibility = ["//:__subpackages__"])
 

--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -1,0 +1,21 @@
+load("@npm_bazel_karma//:defs.bzl", _ts_web_test_suite = "ts_web_test_suite")
+
+def ts_web_test_suite(name, browsers = [], tags = [], **kwargs):
+    _ts_web_test_suite(
+        name = name,
+        tags = tags + ["native", "no-bazelci"],
+        browsers = browsers,
+        **kwargs
+    )
+
+    # BazelCI docker images are missing shares libs to run a subset browser tests:
+    # mac: firefox does not work, chrome works
+    # ubuntu: firefox and chrome do not work --- there are 0 tests to run
+    _ts_web_test_suite(
+        name = "bazelci_" + name,
+        tags = tags + ["native", "no-circleci"],
+        browsers = [
+            "@io_bazel_rules_webtesting//browsers:chromium-local",
+        ],
+        **kwargs
+    )

--- a/tools/generator/src/build-file.js
+++ b/tools/generator/src/build-file.js
@@ -9,8 +9,8 @@ module.exports.writeModuleBuildFile =
       `# Generated BUILD file, see /tools/generator
 load("@io_bazel_rules_sass//:defs.bzl", "sass_binary")
 load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("@npm_bazel_karma//:defs.bzl", "ts_web_test_suite")
 load("@npm_bazel_typescript//:defs.bzl", "ts_library")
+load("//tools:defaults.bzl", "ts_web_test_suite")
 
 package(default_visibility = ["//:__subpackages__"])
 
@@ -86,8 +86,8 @@ ts_web_test_suite(
         `);
 }
 
-    module.exports.writeFeatureModuleBuildFile =
-        function writeFeatureModuleBuildFile(file, {name, featureModuleDeps}) {
+    module.exports.writeFeatureModuleBuildFile = function writeFeatureModuleBuildFile(
+        file, {name, featureModuleDeps}) {
   fs.writeFileSync(
       file,
       // Make Buildifier happy, don't format line below.


### PR DESCRIPTION
Needed for testing downstream in rules_nodejs which tests aheads head of this repo. Long term plan is to move this example to rules_nodejs as the source-of-truth and publish out snapshots to this repo on changes.