### PR TITLE
refactor: use basename with no ext for prodserver check

### DIFF
--- a/e2e/protractor.on-prepare.js
+++ b/e2e/protractor.on-prepare.js
@@ -7,6 +7,7 @@
 
 const protractorUtils = require('@bazel/protractor/protractor-utils');
 const protractor = require('protractor');
+const path = require('path');
 
 module.exports = function(config) {
   // In this example, `@bazel/protractor/protractor-utils` is used to run
@@ -14,7 +15,7 @@ module.exports = function(config) {
   // selected port (given a port flag to pass to the server as an argument).
   // The port used is returned in serverSpec and the protractor serverUrl
   // is the configured.
-  const isProdserver = config.server.endsWith('prodserver');
+  const isProdserver = path.basename(config.server, path.extname(config.server)) === 'prodserver';
   return protractorUtils
       .runServer(config.workspace, config.server, isProdserver ? '-p' : '-port', [])
       .then(serverSpec => {


### PR DESCRIPTION
Needed for https://github.com/bazelbuild/rules_nodejs/pull/1078