### PR TITLE
Make route changes obvious

### DIFF
--- a/src/app/compute/module0/cmp4/cmp4.component.html
+++ b/src/app/compute/module0/cmp4/cmp4.component.html
@@ -1,7 +1,7 @@
 <form [formGroup]="addressForm" novalidate (ngSubmit)="onSubmit()">
   <mat-card class="shipping-card">
     <mat-card-header>
-      <mat-card-title>Billing</mat-card-title>
+      <mat-card-title>Compute</mat-card-title>
     </mat-card-header>
     <mat-card-content>
       <div class="row">

--- a/src/app/datastore/module0/cmp8/cmp8.component.html
+++ b/src/app/datastore/module0/cmp8/cmp8.component.html
@@ -1,7 +1,7 @@
 <form [formGroup]="addressForm" novalidate (ngSubmit)="onSubmit()">
   <mat-card class="shipping-card">
     <mat-card-header>
-      <mat-card-title>Billing</mat-card-title>
+      <mat-card-title>Datastore</mat-card-title>
     </mat-card-header>
     <mat-card-content>
       <div class="row">

--- a/src/app/functions/module0/cmp12/cmp12.component.html
+++ b/src/app/functions/module0/cmp12/cmp12.component.html
@@ -1,7 +1,7 @@
 <form [formGroup]="addressForm" novalidate (ngSubmit)="onSubmit()">
   <mat-card class="shipping-card">
     <mat-card-header>
-      <mat-card-title>Billing</mat-card-title>
+      <mat-card-title>Functions</mat-card-title>
     </mat-card-header>
     <mat-card-content>
       <div class="row">

--- a/src/app/logging/module0/cmp16/cmp16.component.html
+++ b/src/app/logging/module0/cmp16/cmp16.component.html
@@ -1,7 +1,7 @@
 <form [formGroup]="addressForm" novalidate (ngSubmit)="onSubmit()">
   <mat-card class="shipping-card">
     <mat-card-header>
-      <mat-card-title>Billing</mat-card-title>
+      <mat-card-title>Logging</mat-card-title>
     </mat-card-header>
     <mat-card-content>
       <div class="row">

--- a/src/app/monitoring/module0/cmp20/cmp20.component.html
+++ b/src/app/monitoring/module0/cmp20/cmp20.component.html
@@ -1,7 +1,7 @@
 <form [formGroup]="addressForm" novalidate (ngSubmit)="onSubmit()">
   <mat-card class="shipping-card">
     <mat-card-header>
-      <mat-card-title>Billing</mat-card-title>
+      <mat-card-title>Monitoring</mat-card-title>
     </mat-card-header>
     <mat-card-content>
       <div class="row">

--- a/src/app/networking/module0/cmp24/cmp24.component.html
+++ b/src/app/networking/module0/cmp24/cmp24.component.html
@@ -1,7 +1,7 @@
 <form [formGroup]="addressForm" novalidate (ngSubmit)="onSubmit()">
   <mat-card class="shipping-card">
     <mat-card-header>
-      <mat-card-title>Billing</mat-card-title>
+      <mat-card-title>Networking</mat-card-title>
     </mat-card-header>
     <mat-card-content>
       <div class="row">

--- a/src/app/registry/module0/cmp28/cmp28.component.html
+++ b/src/app/registry/module0/cmp28/cmp28.component.html
@@ -1,7 +1,7 @@
 <form [formGroup]="addressForm" novalidate (ngSubmit)="onSubmit()">
   <mat-card class="shipping-card">
     <mat-card-header>
-      <mat-card-title>Billing</mat-card-title>
+      <mat-card-title>Registry</mat-card-title>
     </mat-card-header>
     <mat-card-content>
       <div class="row">

--- a/src/app/storage/module0/cmp32/cmp32.component.html
+++ b/src/app/storage/module0/cmp32/cmp32.component.html
@@ -1,7 +1,7 @@
 <form [formGroup]="addressForm" novalidate (ngSubmit)="onSubmit()">
   <mat-card class="shipping-card">
     <mat-card-header>
-      <mat-card-title>Billing</mat-card-title>
+      <mat-card-title>Storage</mat-card-title>
     </mat-card-header>
     <mat-card-content>
       <div class="row">

--- a/src/app/support/module0/cmp36/cmp36.component.html
+++ b/src/app/support/module0/cmp36/cmp36.component.html
@@ -1,7 +1,7 @@
 <form [formGroup]="addressForm" novalidate (ngSubmit)="onSubmit()">
   <mat-card class="shipping-card">
     <mat-card-header>
-      <mat-card-title>Billing</mat-card-title>
+      <mat-card-title>Support</mat-card-title>
     </mat-card-header>
     <mat-card-content>
       <div class="row">


### PR DESCRIPTION
In the demo prior to the change, route changes (i.e. when a user clicks
a nav link) appear to be broken: nothing changes on the screen. The
success is visible only while looking at the browser JS console.

This change very slightly updates the components to make the topmost
heading on the main pane change to match the navigation click.

(Discovered the value of this during internal Bazel+Angular
walkthroughs.)